### PR TITLE
feat(*): add chai-friendly to allow chainable notation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:import/typescript",
     "plugin:react/recommended",
-    "plugin:jsx-a11y/recommended"
+    "plugin:jsx-a11y/recommended",
+    "plugin:chai-friendly/recommended"
   ],
   "env": {
     "browser": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,6 +1481,11 @@
         }
       }
     },
+    "eslint-plugin-chai-friendly": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.5.0.tgz",
+      "integrity": "sha512-Pxe6z8C9fP0pn2X2nGFU/b3GBOCM/5FVus1hsMwJsXP3R7RiXFl7g0ksJbsc0GxiLyidTW4mEFk77qsNn7Tk7g=="
+    },
     "eslint-plugin-import": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/eslint-plugin-tslint": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
+    "eslint-plugin-chai-friendly": "^0.5.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsdoc": "^22.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",


### PR DESCRIPTION
:smile: 

This is necessary to do assertions such as `expect(value).to.be.true`, otherwise eslint will fail with `Expected an assignment or function call and instead saw an expression`
